### PR TITLE
Apply sbidari's PR to fix tracer leakage

### DIFF
--- a/numpyro/distributions/util.py
+++ b/numpyro/distributions/util.py
@@ -14,6 +14,8 @@ import jax.numpy as jnp
 from jax.scipy.linalg import solve_triangular
 from jax.scipy.special import digamma
 
+from numpyro.util import not_jax_tracer
+
 # Parameters for Transformed Rejection with Squeeze (TRS) algorithm - page 3.
 _tr_params = namedtuple(
     "tr_params", ["c", "b", "a", "alpha", "u_r", "v_r", "m", "log_p", "log1_p", "log_h"]
@@ -692,7 +694,8 @@ class lazy_property(object):
         if instance is None:
             return self
         value = self.wrapped(instance)
-        setattr(instance, self.wrapped.__name__, value)
+        if not_jax_tracer(value):
+            setattr(instance, self.wrapped.__name__, value)
         return value
 
 

--- a/numpyro/version.py
+++ b/numpyro/version.py
@@ -1,4 +1,4 @@
 # Copyright Contributors to the Pyro project.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.15.2"
+__version__ = "0.15.3+rb"


### PR DESCRIPTION
This applies the changes Subekshya Bidari authored in [Numpyro PR number 1843][pr] to fix using a TruncatedNormal distribution (or any other TwoSidedTruncatedDistribution) when running multiple chains in parallel using the NUTs MCMC sampler.

[pr]: https://github.com/pyro-ppl/numpyro/pull/1843